### PR TITLE
ENH: SMC improvements

### DIFF
--- a/src/poppy/history.py
+++ b/src/poppy/history.py
@@ -93,7 +93,7 @@ class SMCHistory(History):
         ax.set_xlabel("Iteration")
         ax.set_ylabel("ESS target")
         return fig
-    
+
     def plot_eff_target(self, ax=None) -> Figure | None:
         if ax is None:
             fig, ax = plt.subplots()

--- a/src/poppy/history.py
+++ b/src/poppy/history.py
@@ -42,6 +42,7 @@ class FlowHistory(History):
 @dataclass
 class SMCHistory(History):
     log_norm_ratio: list[float] = field(default_factory=list)
+    log_norm_ratio_var: list[float] = field(default_factory=list)
     beta: list[float] = field(default_factory=list)
     ess: list[float] = field(default_factory=list)
     ess_target: list[float] = field(default_factory=list)

--- a/src/poppy/history.py
+++ b/src/poppy/history.py
@@ -45,6 +45,7 @@ class SMCHistory(History):
     beta: list[float] = field(default_factory=list)
     ess: list[float] = field(default_factory=list)
     ess_target: list[float] = field(default_factory=list)
+    eff_target: list[float] = field(default_factory=list)
     mcmc_autocorr: list[float] = field(default_factory=list)
     mcmc_acceptance: list[float] = field(default_factory=list)
 
@@ -91,6 +92,16 @@ class SMCHistory(History):
         ax.set_xlabel("Iteration")
         ax.set_ylabel("ESS target")
         return fig
+    
+    def plot_eff_target(self, ax=None) -> Figure | None:
+        if ax is None:
+            fig, ax = plt.subplots()
+        else:
+            fig = None
+        ax.plot(self.eff_target)
+        ax.set_xlabel("Iteration")
+        ax.set_ylabel("Efficiency target")
+        return fig
 
     def plot_mcmc_acceptance(self, ax=None) -> Figure | None:
         if ax is None:
@@ -118,6 +129,7 @@ class SMCHistory(History):
             self.plot_log_norm_ratio,
             self.plot_ess,
             self.plot_ess_target,
+            self.plot_eff_target,
             self.plot_mcmc_acceptance,
         ]
 

--- a/src/poppy/poppy.py
+++ b/src/poppy/poppy.py
@@ -237,11 +237,12 @@ class Poppy:
         elif preconditioning in ["standard", "default"]:
             preconditioning_kwargs = preconditioning_kwargs or {}
             preconditioning_kwargs.setdefault("affine_transform", False)
+            preconditioning_kwargs.setdefault("bounded_to_unbounded", False)
+            preconditioning_kwargs.setdefault("bounded_transform", "logit")
             transform = CompositeTransform(
                 parameters=self.parameters,
                 prior_bounds=self.prior_bounds,
                 periodic_parameters=self.periodic_parameters,
-                bounded_to_unbounded=False,
                 xp=self.xp,
                 device=self.device,
                 **preconditioning_kwargs,

--- a/src/poppy/poppy.py
+++ b/src/poppy/poppy.py
@@ -357,6 +357,8 @@ class Poppy:
         if xp is not None:
             samples = samples.to_namespace(xp)
         samples.parameters = self.parameters
+        logger.info(f"Sampled {len(samples)} samples from the posterior")
+        logger.info(f"Number of likelihood evaluations: {self.n_likelihood_evaluations}")
         logger.info("Sample summary:")
         logger.info(samples)
         if return_history:

--- a/src/poppy/poppy.py
+++ b/src/poppy/poppy.py
@@ -358,7 +358,9 @@ class Poppy:
             samples = samples.to_namespace(xp)
         samples.parameters = self.parameters
         logger.info(f"Sampled {len(samples)} samples from the posterior")
-        logger.info(f"Number of likelihood evaluations: {self.n_likelihood_evaluations}")
+        logger.info(
+            f"Number of likelihood evaluations: {self.n_likelihood_evaluations}"
+        )
         logger.info("Sample summary:")
         logger.info(samples)
         if return_history:

--- a/src/poppy/samplers/mcmc.py
+++ b/src/poppy/samplers/mcmc.py
@@ -25,7 +25,7 @@ class MCMCSampler(Sampler):
                 if samples is None:
                     samples = new_samples[valid]
                 else:
-                    samples = Samples.concatenate(samples, new_samples[valid])
+                    samples = Samples.concatenate([samples, new_samples[valid]])
                 n_samples_drawn += n_valid
 
         if n_samples_drawn > n_samples:

--- a/src/poppy/samplers/mcmc.py
+++ b/src/poppy/samplers/mcmc.py
@@ -25,7 +25,9 @@ class MCMCSampler(Sampler):
                 if samples is None:
                     samples = new_samples[valid]
                 else:
-                    samples = Samples.concatenate([samples, new_samples[valid]])
+                    samples = Samples.concatenate(
+                        [samples, new_samples[valid]]
+                    )
                 n_samples_drawn += n_valid
 
         if n_samples_drawn > n_samples:

--- a/src/poppy/samplers/smc/base.py
+++ b/src/poppy/samplers/smc/base.py
@@ -39,6 +39,99 @@ class SMCSampler(MCMCSampler):
             parameters=parameters,
             preconditioning_transform=preconditioning_transform,
         )
+        self._adapative_target_efficiency = False
+
+    @property
+    def target_efficiency(self):
+        return self._target_efficiency
+    
+    @target_efficiency.setter
+    def target_efficiency(self, value: float|tuple):
+        """Set the target efficiency.
+        
+        Parameters
+        ----------
+        value : float or tuple
+            If a float, the target efficiency to use for all iterations.
+            If a tuple of two floats, the target efficiency will adapt from
+            the first value to the second value over the course of the SMC
+            iterations. See `target_efficiency_rate` for details.
+        """
+        if isinstance(value, float):
+            if not (0 < value < 1):
+                raise ValueError("target_efficiency must be in (0, 1)")
+            self._target_efficiency = value
+            self._adapative_target_efficiency = False
+        elif len(value) != 2:
+                raise ValueError("target_efficiency must be a float or tuple of two floats")
+        else:
+            value = tuple(map(float, value))
+            if not (0 < value[0] < value[1] < 1):
+                raise ValueError("target_efficiency tuple must be in (0, 1) and increasing")
+            self._target_efficiency = value
+            self._adapative_target_efficiency = True
+
+    def current_target_efficiency(self, beta: float) -> float:
+        """Get the current target efficiency based on beta."""
+        if self._adapative_target_efficiency:
+            return (
+                self._target_efficiency[0]
+                + (self._target_efficiency[1] - self._target_efficiency[0]) 
+                * (beta ** self.target_efficiency_rate)
+            )
+        else:
+            return self._target_efficiency
+
+    def determine_beta(self, samples: SMCSamples, beta: float, beta_step: float, min_step: float) -> tuple[float, float]:
+        """Determine the next beta value.
+        
+        Parameters
+        ----------
+        samples : SMCSamples
+            The current samples.
+        beta : float
+            The current beta value.
+        beta_step : float
+            The fixed beta step size if not adaptive.
+        min_step : float
+            The minimum beta step size.
+        
+        Returns
+        -------
+        beta : float
+            The new beta value.
+        min_step : float
+            The new minimum step size if adaptive_min_step is True.
+        """
+        if not self.adaptive:
+            beta += beta_step
+            if beta >= 1.0:
+                beta = 1.0
+        else:
+            beta_prev = beta
+            beta_min = beta_prev
+            beta_max = 1.0
+            tol = 1e-5
+            eff_beta_max = effective_sample_size(samples.log_weights(beta_max)) / len(samples)
+            if eff_beta_max >= self.current_target_efficiency(beta_prev):
+                beta_min = 1.0
+            target_eff = self.current_target_efficiency(beta_prev)
+            while beta_max - beta_min > tol:
+                beta_try = 0.5 * (beta_max + beta_min)
+                eff = effective_sample_size(
+                    samples.log_weights(beta_try)
+                ) / len(samples)
+                if eff >= target_eff:
+                    beta_min = beta_try
+                else:
+                    beta_max = beta_try
+            beta_star = beta_min
+
+            if self.adaptive_min_step:
+                min_step = min_step * (1 - beta_prev) / (1 - beta_star)
+            beta = max(beta_star, beta_prev + min_step)
+            beta = min(beta, 1.0)
+        return beta, min_step
 
     @track_calls
     def sample(
@@ -46,7 +139,10 @@ class SMCSampler(MCMCSampler):
         n_samples: int,
         n_steps: int = None,
         adaptive: bool = True,
+        min_step: float | None = None,
+        max_n_steps: int | None = None,
         target_efficiency: float = 0.5,
+        target_efficiency_rate: float = 1.0,
         n_final_samples: int | None = None,
     ):
         samples = self.draw_initial_samples(n_samples)
@@ -64,45 +160,49 @@ class SMCSampler(MCMCSampler):
 
         self.history = SMCHistory()
 
+        self.target_efficiency = target_efficiency
+        self.target_efficiency_rate = target_efficiency_rate
+
         if n_steps is not None:
             beta_step = 1 / n_steps
         elif not adaptive:
             raise ValueError("Either n_steps or adaptive=True must be set")
         else:
             beta_step = np.nan
+        self.adaptive = adaptive
         beta = 0.0
-        beta_min = 0.0
+        
+        if min_step is None:
+            if max_n_steps is None:
+                min_step = 0.0
+                self.adaptive_min_step = False
+            else:
+                min_step = 1 / max_n_steps
+                self.adaptive_min_step = True
+        else:
+            self.adaptive_min_step = False
+
         iterations = 0
         while True:
             iterations += 1
-            if not adaptive:
-                beta += beta_step
-                if beta >= 1.0:
-                    beta = 1.0
-            else:
-                beta_max = 1.0
-                ess = effective_sample_size(samples.log_weights(beta_max))
-                eff = ess / len(samples.x)
-                if self.xp.isnan(eff):
-                    raise ValueError("Effective sample size is NaN")
-                beta = beta_max
-                while True:
-                    ess = effective_sample_size(samples.log_weights(beta))
-                    eff = ess / n_samples
-                    if eff >= target_efficiency:
-                        beta_min = beta
-                        break
-                    else:
-                        beta_max = beta
-                    # Make beta is never larger than 1
-                    beta = min(0.5 * (beta_max + beta_min), 1)
+
+            beta, min_step = self.determine_beta(
+                samples, beta, beta_step, min_step,
+            )
+            self.history.eff_target.append(self.current_target_efficiency(beta))
+
             logger.info(f"it {iterations} - beta: {beta}")
             self.history.beta.append(beta)
 
             ess = effective_sample_size(samples.log_weights(beta))
+            eff = ess / len(samples)
+            if eff < 0.1:
+                logger.warning(
+                    f"it {iterations} - Low sample efficiency: {eff:.2f}"
+                )
             self.history.ess.append(ess)
             logger.info(
-                f"it {iterations} - ESS: {ess:.1f} ({ess / n_samples:.2f} efficiency)"
+                f"it {iterations} - ESS: {ess:.1f} ({eff:.2f} efficiency)"
             )
             self.history.ess_target.append(
                 effective_sample_size(samples.log_weights(1.0))
@@ -114,22 +214,26 @@ class SMCSampler(MCMCSampler):
                 f"it {iterations} - Log evidence ratio: {log_evidence_ratio}"
             )
 
-            if beta == 1.0:
-                if n_final_samples is None:
-                    n_final_samples = n_samples
-                logger.info(f"Final number of samples: {n_final_samples}")
-                samples = samples.resample(beta, n_samples=n_final_samples)
-            else:
-                samples = samples.resample(beta)
+            samples = samples.resample(beta, rng=self.rng)
 
             samples = self.mutate(samples, beta)
-            if beta == 1.0:
+            if beta == 1.0 or (max_n_steps is not None and iterations >= max_n_steps):
                 break
+
+        # If n_final_samples is not None, perform additional mutations steps
+        if n_final_samples is not None:
+            logger.info(f"Generating {n_final_samples} final samples")
+            final_samples = samples.resample(
+                1.0, n_samples=n_final_samples - len(samples), rng=self.rng
+            )
+            final_samples = self.mutate(final_samples, 1.0)
+            samples = SMCSamples.concatenate([samples, final_samples])
 
         samples.log_evidence = samples.xp.sum(
             asarray(self.history.log_norm_ratio, self.xp)
         )
         samples.log_evidence_error = samples.xp.nan
+
         final_samples = samples.to_standard_samples()
         logger.info(f"Log evidence: {final_samples.log_evidence:.2f}")
         return final_samples

--- a/src/poppy/samplers/smc/base.py
+++ b/src/poppy/samplers/smc/base.py
@@ -28,6 +28,7 @@ class SMCSampler(MCMCSampler):
         prior_flow: Flow,
         xp: Callable,
         parameters: list[str] | None = None,
+        rng: np.random.Generator | None = None,
         preconditioning_transform: Callable | None = None,
     ):
         super().__init__(
@@ -39,6 +40,7 @@ class SMCSampler(MCMCSampler):
             parameters=parameters,
             preconditioning_transform=preconditioning_transform,
         )
+        self.rng = rng or np.random.default_rng()
         self._adapative_target_efficiency = False
 
     @property

--- a/src/poppy/samplers/smc/base.py
+++ b/src/poppy/samplers/smc/base.py
@@ -224,10 +224,9 @@ class SMCSampler(MCMCSampler):
         if n_final_samples is not None:
             logger.info(f"Generating {n_final_samples} final samples")
             final_samples = samples.resample(
-                1.0, n_samples=n_final_samples - len(samples), rng=self.rng
+                1.0, n_samples=n_final_samples, rng=self.rng
             )
-            final_samples = self.mutate(final_samples, 1.0)
-            samples = SMCSamples.concatenate([samples, final_samples])
+            samples = self.mutate(final_samples, 1.0)
 
         samples.log_evidence = samples.xp.sum(
             asarray(self.history.log_norm_ratio, self.xp)

--- a/src/poppy/samplers/smc/blackjax.py
+++ b/src/poppy/samplers/smc/blackjax.py
@@ -1,6 +1,8 @@
 import logging
 from functools import partial
 
+import numpy as np
+
 from ...samples import SMCSamples
 from ...utils import asarray, to_numpy, track_calls
 from .base import SMCSampler
@@ -20,6 +22,7 @@ class BlackJAXSMC(SMCSampler):
         xp,
         parameters=None,
         preconditioning_transform=None,
+        rng: np.random.Generator | None = None,  # New parameter
     ):
         # For JAX compatibility, we'll keep the original xp
         super().__init__(
@@ -32,6 +35,7 @@ class BlackJAXSMC(SMCSampler):
             preconditioning_transform=preconditioning_transform,
         )
         self.key = None
+        self.rng = rng or np.random.default_rng()
 
     def log_prob(self, x, beta=None):
         """Log probability function compatible with BlackJAX."""

--- a/src/poppy/samplers/smc/blackjax.py
+++ b/src/poppy/samplers/smc/blackjax.py
@@ -128,7 +128,7 @@ class BlackJAXSMC(SMCSampler):
             n_final_samples=n_final_samples,
         )
 
-    def mutate(self, particles, beta):
+    def mutate(self, particles, beta, n_steps=None):
         """Mutate particles using BlackJAX MCMC."""
         import blackjax
         import jax
@@ -149,6 +149,8 @@ class BlackJAXSMC(SMCSampler):
 
         # Choose BlackJAX algorithm
         algorithm = self.sampler_kwargs["algorithm"].lower()
+
+        n_steps = n_steps or self.sampler_kwargs["n_steps"]
 
         if algorithm == "rwmh" or algorithm == "random_walk":
             # Initialize Random Walk Metropolis-Hastings sampler
@@ -194,7 +196,7 @@ class BlackJAXSMC(SMCSampler):
                     state, info = rwmh.step(key, state)
                     return state, (state, info)
 
-                keys = jax.random.split(key, self.sampler_kwargs["n_steps"])
+                keys = jax.random.split(key, n_steps)
                 final_state, (states, infos) = jax.lax.scan(
                     one_step, state, keys
                 )

--- a/src/poppy/samplers/smc/blackjax.py
+++ b/src/poppy/samplers/smc/blackjax.py
@@ -74,6 +74,7 @@ class BlackJAXSMC(SMCSampler):
         n_steps: int = None,
         adaptive: bool = True,
         target_efficiency: float = 0.5,
+        target_efficiency_rate: float = 1.0,
         n_final_samples: int | None = None,
         sampler_kwargs: dict | None = None,
         rng_key=None,
@@ -123,6 +124,7 @@ class BlackJAXSMC(SMCSampler):
             n_steps=n_steps,
             adaptive=adaptive,
             target_efficiency=target_efficiency,
+            target_efficiency_rate=target_efficiency_rate,
             n_final_samples=n_final_samples,
         )
 

--- a/src/poppy/samplers/smc/emcee.py
+++ b/src/poppy/samplers/smc/emcee.py
@@ -17,6 +17,7 @@ class EmceeSMC(NumpySMCSampler):
         n_steps: int = None,
         adaptive: bool = True,
         target_efficiency: float = 0.5,
+        target_efficiency_rate: float = 1.0,
         sampler_kwargs: dict | None = None,
         n_final_samples: int | None = None,
     ):
@@ -29,6 +30,7 @@ class EmceeSMC(NumpySMCSampler):
             n_steps=n_steps,
             adaptive=adaptive,
             target_efficiency=target_efficiency,
+            target_efficiency_rate=target_efficiency_rate,
             n_final_samples=n_final_samples,
         )
 

--- a/src/poppy/samplers/smc/emcee.py
+++ b/src/poppy/samplers/smc/emcee.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 
 import numpy as np
@@ -34,7 +35,7 @@ class EmceeSMC(NumpySMCSampler):
             n_final_samples=n_final_samples,
         )
 
-    def mutate(self, particles, beta):
+    def mutate(self, particles, beta, n_steps=None):
         import emcee
 
         logger.info("Mutating particles")
@@ -47,7 +48,10 @@ class EmceeSMC(NumpySMCSampler):
             moves=self.emcee_moves,
         )
         z = self.fit_preconditioning_transform(particles.x)
-        sampler.run_mcmc(z, **self.sampler_kwargs)
+        kwargs = copy.deepcopy(self.sampler_kwargs)
+        if n_steps is not None:
+            kwargs["nsteps"] = n_steps
+        sampler.run_mcmc(z, **kwargs)
         self.history.mcmc_acceptance.append(
             np.mean(sampler.acceptance_fraction)
         )

--- a/src/poppy/samplers/smc/minipcn.py
+++ b/src/poppy/samplers/smc/minipcn.py
@@ -20,8 +20,11 @@ class MiniPCNSMC(NumpySMCSampler):
         self,
         n_samples: int,
         n_steps: int = None,
+        min_step: float | None = None,
+        max_n_steps: int | None = None,
         adaptive: bool = True,
         target_efficiency: float = 0.5,
+        target_efficiency_rate: float = 1.0,
         n_final_samples: int | None = None,
         sampler_kwargs: dict | None = None,
         rng: np.random.Generator | None = None,
@@ -36,7 +39,10 @@ class MiniPCNSMC(NumpySMCSampler):
             n_steps=n_steps,
             adaptive=adaptive,
             target_efficiency=target_efficiency,
+            target_efficiency_rate=target_efficiency_rate,
             n_final_samples=n_final_samples,
+            min_step=min_step,
+            max_n_steps=max_n_steps,
         )
 
     def mutate(self, particles, beta):

--- a/src/poppy/samplers/smc/minipcn.py
+++ b/src/poppy/samplers/smc/minipcn.py
@@ -45,7 +45,7 @@ class MiniPCNSMC(NumpySMCSampler):
             max_n_steps=max_n_steps,
         )
 
-    def mutate(self, particles, beta):
+    def mutate(self, particles, beta, n_steps=None):
         from minipcn import Sampler
 
         log_prob_fn = partial(self.log_prob, beta=beta)
@@ -63,7 +63,7 @@ class MiniPCNSMC(NumpySMCSampler):
         z = to_numpy(self.fit_preconditioning_transform(particles.x))
         chain, history = sampler.sample(
             z,
-            n_steps=self.sampler_kwargs["n_steps"],
+            n_steps=n_steps or self.sampler_kwargs["n_steps"],
         )
         x = self.preconditioning_transform.inverse(chain[-1])[0]
 

--- a/src/poppy/samples.py
+++ b/src/poppy/samples.py
@@ -401,10 +401,10 @@ class SMCSamples(BaseSamples):
     def log_evidence_ratio(self, beta: float) -> float:
         log_w = self.unnormalized_log_weights(beta)
         return logsumexp(log_w) - math.log(len(self.x))
-    
+
     def log_evidence_ratio_variance(self, beta: float) -> float:
         """Estimate the variance of the log evidence ratio using the delta method.
-        
+
         Defined as Var(log Z) = Var(w) / (E[w])^2 where w are the unnormalized weights.
         """
         log_w = self.unnormalized_log_weights(beta)
@@ -412,7 +412,9 @@ class SMCSamples(BaseSamples):
         u = self.xp.exp(log_w - m)
         mean_w = self.xp.mean(u)
         var_w = self.xp.var(u)
-        return var_w / (len(self) * (mean_w ** 2)) if mean_w != 0 else self.xp.nan
+        return (
+            var_w / (len(self) * (mean_w**2)) if mean_w != 0 else self.xp.nan
+        )
 
     def log_weights(self, beta: float) -> Array:
         log_w = self.unnormalized_log_weights(beta)
@@ -421,9 +423,16 @@ class SMCSamples(BaseSamples):
         log_evidence_ratio = logsumexp(log_w) - math.log(len(self.x))
         return log_w + log_evidence_ratio
 
-    def resample(self, beta, n_samples: int | None = None, rng: np.random.Generator = None) -> "SMCSamples":
+    def resample(
+        self,
+        beta,
+        n_samples: int | None = None,
+        rng: np.random.Generator = None,
+    ) -> "SMCSamples":
         if beta == self.beta and n_samples is None:
-            logger.warning("Resampling with the same beta value, returning identical samples")
+            logger.warning(
+                "Resampling with the same beta value, returning identical samples"
+            )
             return self
         if rng is None:
             rng = np.random.default_rng()


### PR DESCRIPTION
Various improvements to the SMC sampler:

- Support for flows that have support outside the prior bounds
- More options when using the standard preconditioning
- Adaptive target efficiency during sampling -- currently implemented (`low + (high - low) ** p`) where `p` is configurable via `target_efficiency_rate`. To use this `target_efficiency` should be a length-2 tuple.
- Draw final samples after the final iteration rather than during the final iteration. This should make the final samples more robust and could allow for using fewer steps.
- Fix the rng for the `resample` method.
- Add indexing support to `BaseSamples`
- Add `BaseSamples.concatenate`